### PR TITLE
Add bio.tools to wrappers

### DIFF
--- a/tools/frogs/affiliation_filters.xml
+++ b/tools/frogs/affiliation_filters.xml
@@ -3,7 +3,9 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="requirements"/>   <command detect_errors="exit_code">
+    <expand macro="xrefs"/>
+    <expand macro="requirements"/>
+    <command detect_errors="exit_code">
 		affiliation_filters.py
 			--input-biom '$input_biom'
 			--input-fasta '$input_fasta'

--- a/tools/frogs/affiliation_postprocess.xml
+++ b/tools/frogs/affiliation_postprocess.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code">
         affiliation_postprocess.py

--- a/tools/frogs/affiliation_stats.xml
+++ b/tools/frogs/affiliation_stats.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+	<expand macro="xrefs"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code">
 		affiliation_stats.py

--- a/tools/frogs/biom_to_stdBiom.xml
+++ b/tools/frogs/biom_to_stdBiom.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+	<expand macro="xrefs"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code">
 	biom_to_stdBiom.py

--- a/tools/frogs/biom_to_tsv.xml
+++ b/tools/frogs/biom_to_tsv.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+	<expand macro="xrefs"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code">
 	biom_to_tsv.py

--- a/tools/frogs/cluster_filters.xml
+++ b/tools/frogs/cluster_filters.xml
@@ -21,7 +21,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-
+	<expand macro="xrefs"/>
     <expand macro="requirements">
         <requirement type="package" version="2.10">blast</requirement>
     </expand>

--- a/tools/frogs/cluster_stats.xml
+++ b/tools/frogs/cluster_stats.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+	<expand macro="xrefs"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code">
 	cluster_stats.py

--- a/tools/frogs/clustering.xml
+++ b/tools/frogs/clustering.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements">
         <requirement type="package" version="3.0.0">swarm</requirement>
     </expand>

--- a/tools/frogs/demultiplex.xml
+++ b/tools/frogs/demultiplex.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+	<expand macro="xrefs"/>
     <expand macro="requirements" />
     <command detect_errors="exit_code">
 		demultiplex.py

--- a/tools/frogs/deseq2_preprocess.xml
+++ b/tools/frogs/deseq2_preprocess.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq">
         <requirement type="package" version="1.34.0">bioconductor-deseq2</requirement>
         <requirement type="package" version="1.6.6">r-optparse</requirement>

--- a/tools/frogs/deseq2_visualisation.xml
+++ b/tools/frogs/deseq2_visualisation.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq">
         <requirement type="package" version="1.34.0">bioconductor-deseq2</requirement>
         <requirement type="package" version="0.18">r-dt</requirement>

--- a/tools/frogs/frogsfunc_functions.xml
+++ b/tools/frogs/frogsfunc_functions.xml
@@ -17,14 +17,11 @@
 -->
 <tool id="FROGSFUNC_step2_functions" name="FROGSFUNC_2_functions" version= "@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Calculates functions abundances in each sample. </description>
-
-  <macros>
-        <import>macros.xml</import>
-  </macros>
-
-  <expand macro="requirements_frogsfunc" />
-
-
+    <macros>
+            <import>macros.xml</import>
+    </macros>
+    <expand macro="xrefs"/>
+    <expand macro="requirements_frogsfunc" />
     <stdio>
         <exit_code range="1:" />
         <exit_code range=":-1" />

--- a/tools/frogs/frogsfunc_pathways.xml
+++ b/tools/frogs/frogsfunc_pathways.xml
@@ -22,6 +22,7 @@
         <import>macros.xml</import>
   </macros>
 
+  <expand macro="xrefs"/>
   <expand macro="requirements_frogsfunc" />
 
   <stdio>

--- a/tools/frogs/frogsfunc_placeseqs.xml
+++ b/tools/frogs/frogsfunc_placeseqs.xml
@@ -21,7 +21,7 @@
   <macros>
         <import>macros.xml</import>
   </macros>
-
+  <expand macro="xrefs"/>
   <expand macro="requirements_frogsfunc" >
 	<requirement type="package" version="4.5.2">dendropy</requirement>
   </expand>

--- a/tools/frogs/itsx.xml
+++ b/tools/frogs/itsx.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements">
         <requirement type="package" version="1.1.2">itsx</requirement>
     </expand>

--- a/tools/frogs/macros.xml
+++ b/tools/frogs/macros.xml
@@ -2,6 +2,12 @@
 <macros>
     <token name="@TOOL_VERSION@">4.1.0</token>
     <token name="@VERSION_SUFFIX@">3</token>
+
+    <xml name="xrefs">
+        <xrefs>
+            <xref type="bio.tools">frogs</xref>
+        </xrefs>
+    </xml>
     
     <xml name="requirements">
         <requirements>

--- a/tools/frogs/normalisation.xml
+++ b/tools/frogs/normalisation.xml
@@ -21,6 +21,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+	<expand macro="xrefs"/>
     <expand macro="requirements"/>
 
         <stdio>

--- a/tools/frogs/phyloseq_alpha_diversity.xml
+++ b/tools/frogs/phyloseq_alpha_diversity.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq" />
     <command detect_errors="exit_code">
     phyloseq_alpha_diversity.py

--- a/tools/frogs/phyloseq_beta_diversity.xml
+++ b/tools/frogs/phyloseq_beta_diversity.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq">
         <requirement type="package" version="2.3">r-gridextra</requirement>
     </expand>

--- a/tools/frogs/phyloseq_clustering.xml
+++ b/tools/frogs/phyloseq_clustering.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq" />
     <command detect_errors="exit_code">
     phyloseq_clustering.py

--- a/tools/frogs/phyloseq_composition.xml
+++ b/tools/frogs/phyloseq_composition.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq">
         <requirement type="package" version="4.9.3">r-plotly</requirement>
     </expand>

--- a/tools/frogs/phyloseq_import_data.xml
+++ b/tools/frogs/phyloseq_import_data.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq" />
     <command detect_errors="exit_code">
         phyloseq_import_data.py

--- a/tools/frogs/phyloseq_manova.xml
+++ b/tools/frogs/phyloseq_manova.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+	<expand macro="xrefs"/>
     <expand macro="requirements_phyloseq" />
     <command detect_errors="exit_code">
     phyloseq_manova.py

--- a/tools/frogs/phyloseq_structure.xml
+++ b/tools/frogs/phyloseq_structure.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements_phyloseq" >
         <requirement type="package" version="4.9.3">r-plotly</requirement>
     </expand>

--- a/tools/frogs/preprocess.xml
+++ b/tools/frogs/preprocess.xml
@@ -3,6 +3,7 @@
      <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements">
         <requirement type="package" version="2.17.0">vsearch</requirement>
         <requirement type="package" version="1.2.11">flash</requirement>

--- a/tools/frogs/remove_chimera.xml
+++ b/tools/frogs/remove_chimera.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements">
         <requirement type="package" version="2.17.0">vsearch</requirement>
     </expand>

--- a/tools/frogs/taxonomic_affiliation.xml
+++ b/tools/frogs/taxonomic_affiliation.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements">
         <requirement type="package" version="2.10">blast</requirement>
         <requirement type="package" version="6.6.0">emboss</requirement>

--- a/tools/frogs/tree.xml
+++ b/tools/frogs/tree.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements">
         <requirement type="package" version="7.407">mafft</requirement>
         <requirement type="package" version="2.1.9">fasttree</requirement>

--- a/tools/frogs/tsv_to_biom.xml
+++ b/tools/frogs/tsv_to_biom.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements" />
     <command detect_errors="exit_code">
 	tsv_to_biom.py


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

---

Hi,

This PR links the tools to its bio.tools entry: https://bio.tools/frogs
It will be useful to get EDAM ontology annotations for the tool directly from bio.tools, e.g. for grouping tools by topics for the 
new Galaxy tool panel

Thanks,

Bérénice
